### PR TITLE
fix: change satisfies by "as" for babel type check

### DIFF
--- a/src/server/uploadthing.ts
+++ b/src/server/uploadthing.ts
@@ -62,6 +62,8 @@ export const ourFileRouter = {
       console.log('Upload complete for userId:', metadata.userId);
       console.log('file', file);
     }),
-} satisfies FileRouter;
+} as FileRouter;
+
+// satisfies FileRouter;
 
 export type OurFileRouter = typeof ourFileRouter;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -92,4 +92,6 @@ export default {
     },
   },
   plugins: [require('tailwindcss-animate')],
-} satisfies Config;
+} as Config;
+
+// satisfies Config;


### PR DESCRIPTION
* next v12.3.4 doesn't support satisfies when using babel